### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   build:
 
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/abdlelah2024/abdlelah2024-shefaa-clinic-app/security/code-scanning/3](https://github.com/abdlelah2024/abdlelah2024-shefaa-clinic-app/security/code-scanning/3)

To fix the issue, you should explicitly add a `permissions` block to the job definition (or to the workflow root) in `.github/workflows/node.js.yml` to limit the GITHUB_TOKEN privileges for the workflow. For a typical Node.js CI job that installs dependencies, builds, and runs tests, only read access to repository contents is required, so setting `contents: read` is usually sufficient. Place this key immediately below either the job name (`build:`) or at the top level of the workflow (directly after `name:`), depending on whether you want permissions to apply to all jobs or only one. In this case, since there is only one job, either location is acceptable; adding it at the job level follows CodeQL’s suggestion (since it flagged line 15).

No other methods, imports, or definitions are needed—just the addition of the `permissions` block in the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
